### PR TITLE
Change ezpublish-kernel version constraint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "ezsystems/ezpublish-kernel": "^6.0"
+        "ezsystems/ezpublish-kernel": "^6.0||^7.0"
     },
     "autoload" : {
         "psr-0" : {


### PR DESCRIPTION
This PR contains update in the `ezsystems/ezpublish-kernel` version constraint to make this bundle works with the new eZ Platform v2. 

Moreover, could you please do the release of this bundle?